### PR TITLE
Redirect example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
   "examples/proxy",
   "examples/state",
   "examples/time",
+  "examples/redirect",
 ]

--- a/examples/redirect/Cargo.toml
+++ b/examples/redirect/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "redirect"
+version = "0.0.0"
+workspace = "../.."
+
+[dependencies]
+shio = { path = "../../lib" }

--- a/examples/redirect/src/main.rs
+++ b/examples/redirect/src/main.rs
@@ -1,0 +1,28 @@
+extern crate shio;
+
+use shio::prelude::*;
+
+// redirect the current
+fn redirect_to(_: Context) -> Response {
+    Response::build()
+        .status(StatusCode::SeeOther)
+        .header(shio::header::Location::new("/redirected"))
+        .into()
+}
+
+fn redirected(_: Context) -> Response {
+    Response::with("You has been redirected!\n")
+}
+
+fn index(_: Context) -> Response {
+    Response::with("Hello World!\n")
+}
+
+fn main() {
+    Shio::default()
+        .route((Method::Get, "/", index))
+        .route((Method::Get, "/redirect", redirect_to))
+        .route((Method::Get, "/redirected", redirected))
+        .run(":7878")
+        .unwrap();
+}


### PR DESCRIPTION
This PR add a redirect example.
Should we provide a way to make this integrated into shio directly (like the [Redirect](https://api.rocket.rs/rocket/response/struct.Redirect.html) responder on Rocket)?