### PR TITLE
Add global state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,5 @@ members = [
   "examples/redirect",
   "examples/templates_askama",
   "examples/postgres",
+  "examples/global_state",
 ]

--- a/examples/global_state/Cargo.toml
+++ b/examples/global_state/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "global_state"
+version = "0.0.0"
+workspace = "../.."
+
+[dependencies]
+shio = { path = "../../lib" }

--- a/examples/global_state/src/main.rs
+++ b/examples/global_state/src/main.rs
@@ -1,0 +1,31 @@
+extern crate shio;
+
+use std::thread;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use shio::prelude::*;
+use shio::context::Key;
+
+pub struct GlobalCounter;
+
+impl Key for GlobalCounter {
+    type Value = AtomicUsize;
+}
+
+fn hello(context: Context) -> Response {
+    let counter = context
+        .get_global::<GlobalCounter>()
+        .fetch_add(1, Ordering::Relaxed);
+    Response::with(format!(
+        "Hi, #{} (from thread: {:?})\n",
+        counter,
+        thread::current().id()
+    ))
+}
+
+fn main() {
+    Shio::default()
+        .manage::<GlobalCounter>(AtomicUsize::default())
+        .route((Method::Get, "/", hello))
+        .run(":7878")
+        .unwrap();
+}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,7 +20,7 @@ hyper = "0.11"
 tokio-proto = "0.1.1"
 regex = "0.2"
 log = "0.3"
-typemap = "0.3"
+unsafe-any = "0.4.2"
 
 [features]
 default = []

--- a/lib/src/context.rs
+++ b/lib/src/context.rs
@@ -1,6 +1,8 @@
 use std::ops::Deref;
+use std::sync::Arc;
 
 use tokio_core::reactor::Handle;
+use unsafe_any::UnsafeAny;
 
 use request::{Body, Request};
 use util::typemap::TypeMap;
@@ -19,14 +21,20 @@ pub struct Context {
     state: TypeMap,
     handle: Handle,
     request: Request,
+    global_state: Arc<TypeMap<UnsafeAny + Send + Sync>>,
 }
 
 impl Context {
-    pub(crate) fn new(handle: Handle, request: Request) -> Self {
+    pub(crate) fn new(
+        handle: Handle,
+        request: Request,
+        global_state: Arc<TypeMap<UnsafeAny + Send + Sync>>,
+    ) -> Self {
         Self {
             handle,
             request,
             state: TypeMap::new(),
+            global_state,
         }
     }
 
@@ -58,6 +66,26 @@ impl Context {
     /// Gets a value from the request context.
     pub fn try_get<K: Key>(&self) -> Option<&K::Value> {
         self.state.get::<K>()
+    }
+
+    /// Gets a value from the global context.
+    ///
+    /// # Panics
+    ///
+    /// If there is no value in the global context of the given type.
+    pub fn get_global<K: Key>(&self) -> &K::Value
+    where
+        <K as Key>::Value: Send + Sync,
+    {
+        self.global_state.get::<K>().unwrap()
+    }
+
+    /// Gets a value from the global context.
+    pub fn try_get_global<K: Key>(&self) -> Option<&K::Value>
+    where
+        <K as Key>::Value: Send + Sync,
+    {
+        self.global_state.get::<K>()
     }
 }
 

--- a/lib/src/context.rs
+++ b/lib/src/context.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
 use tokio_core::reactor::Handle;
-use typemap::TypeMap;
-pub use typemap::Key;
 
 use request::{Body, Request};
+use util::typemap::TypeMap;
+pub use util::typemap::Key;
 
 /// `Context` represents the context of the current HTTP request.
 ///

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,7 +10,7 @@ extern crate num_cpus;
 extern crate regex;
 extern crate tokio_core;
 extern crate tokio_io;
-extern crate typemap;
+extern crate unsafe_any;
 
 pub mod context;
 mod handler;
@@ -21,6 +21,7 @@ pub mod response;
 pub mod request;
 pub mod errors;
 pub mod router;
+pub mod util;
 
 pub use hyper::{header, Method, StatusCode};
 

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -125,6 +125,8 @@ impl Handler for Router {
 mod tests {
     use tokio_core::reactor::Core;
     use hyper;
+    use util::typemap::TypeMap;
+    use std::sync::Arc;
 
     use super::{Parameters, Router};
     use {Context, Handler, Request, Response, StatusCode};
@@ -212,7 +214,7 @@ mod tests {
         let request = Request::new(
             hyper::Request::new(Get, "/user/3289".parse().unwrap()).deconstruct(),
         );
-        let context = Context::new(core.handle(), request);
+        let context = Context::new(core.handle(), request, Arc::new(TypeMap::custom()));
 
         let work = router.call(context);
 
@@ -250,7 +252,7 @@ mod tests {
         let request = Request::new(
             hyper::Request::new(Get, "/static/path/to/file/is/here".parse().unwrap()).deconstruct(),
         );
-        let context = Context::new(core.handle(), request);
+        let context = Context::new(core.handle(), request, Arc::new(TypeMap::custom()));
 
         let work = router.call(context);
 

--- a/lib/src/router/parameters.rs
+++ b/lib/src/router/parameters.rs
@@ -2,7 +2,7 @@ use std::ops::Index;
 use std::sync::Arc;
 use std::collections::HashMap;
 
-use typemap::Key;
+use util::typemap::Key;
 use regex::Captures;
 
 pub struct Parameters {

--- a/lib/src/service.rs
+++ b/lib/src/service.rs
@@ -5,10 +5,12 @@ use std::panic::AssertUnwindSafe;
 use hyper;
 use tokio_core::reactor::Handle;
 use futures::{future, Future, IntoFuture};
+use unsafe_any::UnsafeAny;
 
 use request::Request;
 use handler::{default_catch, Handler};
 use context::Context;
+use util::typemap::TypeMap;
 use ext::BoxFuture;
 
 // FIXME: Why does #[derive(Clone)] not work here? This _seems_ like a implementation that
@@ -21,14 +23,23 @@ where
 {
     handler: Arc<H>,
     handle: Handle,
+    global_state: Arc<TypeMap<UnsafeAny + Send + Sync>>,
 }
 
 impl<H: Handler + 'static> Service<H>
 where
     <H::Result as IntoFuture>::Error: fmt::Debug + Send,
 {
-    pub(crate) fn new(handler: Arc<H>, handle: Handle) -> Self {
-        Self { handler, handle }
+    pub(crate) fn new(
+        handler: Arc<H>,
+        handle: Handle,
+        global_state: Arc<TypeMap<UnsafeAny + Send + Sync>>,
+    ) -> Self {
+        Self {
+            handler,
+            handle,
+            global_state,
+        }
     }
 }
 
@@ -40,6 +51,7 @@ where
         Self {
             handler: self.handler.clone(),
             handle: self.handle.clone(),
+            global_state: self.global_state.clone(),
         }
     }
 }
@@ -55,7 +67,7 @@ where
 
     fn call(&self, request: Self::Request) -> Self::Future {
         let request = Request::new(request.deconstruct());
-        let ctx = Context::new(self.handle.clone(), request);
+        let ctx = Context::new(self.handle.clone(), request, self.global_state.clone());
         let handler = self.handler.clone();
 
         Box::new(

--- a/lib/src/util/mod.rs
+++ b/lib/src/util/mod.rs
@@ -1,0 +1,3 @@
+
+
+pub mod typemap;

--- a/lib/src/util/typemap.rs
+++ b/lib/src/util/typemap.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+use std::any::{Any, TypeId};
+use std::hash::{BuildHasherDefault, Hasher};
+use std::ptr;
+
+use unsafe_any::{UnsafeAny, UnsafeAnyExt};
+
+#[derive(Default)]
+pub struct TypeIdHasher {
+    value: u64,
+}
+
+impl Hasher for TypeIdHasher {
+    fn finish(&self) -> u64 {
+        self.value
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        // This expects to receive one and exactly one 64-bit value
+        debug_assert!(bytes.len() == 8);
+        unsafe {
+            ptr::copy_nonoverlapping(&bytes[0] as *const u8 as *const u64, &mut self.value, 1)
+        }
+    }
+}
+
+#[doc(hidden)]
+pub unsafe trait Implements<A: ?Sized + UnsafeAnyExt> {
+    fn into_object(self) -> Box<A>;
+}
+
+unsafe impl<T: UnsafeAny> Implements<UnsafeAny> for T {
+    fn into_object(self) -> Box<UnsafeAny> {
+        Box::new(self)
+    }
+}
+
+unsafe impl<T: UnsafeAny + Send + Sync> Implements<(UnsafeAny + Send + Sync)> for T {
+    fn into_object(self) -> Box<UnsafeAny + Send + Sync> {
+        Box::new(self)
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct TypeMap<A: ?Sized = UnsafeAny>
+where
+    A: UnsafeAnyExt,
+{
+    data: HashMap<TypeId, Box<A>, BuildHasherDefault<TypeIdHasher>>,
+}
+
+/// This trait defines the relationship between keys and values in a `TypeMap`.
+///
+/// It is implemented for Keys, with a phantom associated type for the values.
+pub trait Key: Any {
+    /// The value type associated with this key type.
+    type Value: Any;
+}
+
+impl TypeMap {
+    /// Create a new, empty TypeMap.
+    pub fn new() -> TypeMap {
+        TypeMap::custom()
+    }
+}
+
+impl<A: UnsafeAnyExt + ?Sized> TypeMap<A> {
+    /// Create a new, empty TypeMap.
+    ///
+    /// Can be used with any `A` parameter; `new` is specialized to get around
+    /// the required type annotations when using this function.
+    pub fn custom() -> TypeMap<A> {
+        TypeMap {
+            data: HashMap::default(),
+        }
+    }
+
+    /// Insert a value into the map with a specified key type.
+    pub fn insert<K: Key>(&mut self, val: K::Value) -> Option<K::Value>
+    where
+        K::Value: Any + Implements<A>,
+    {
+        self.data
+            .insert(TypeId::of::<K>(), val.into_object())
+            .map(|v| unsafe { *v.downcast_unchecked::<K::Value>() })
+    }
+
+    /// Find a value in the map and get a reference to it.
+    pub fn get<K: Key>(&self) -> Option<&K::Value>
+    where
+        K::Value: Any + Implements<A>,
+    {
+        self.data
+            .get(&TypeId::of::<K>())
+            .map(|v| unsafe { v.downcast_ref_unchecked::<K::Value>() })
+    }
+
+    /// Check if a key has an associated value stored in the map.
+    pub fn contains<K: Key>(&self) -> bool {
+        self.data.contains_key(&TypeId::of::<K>())
+    }
+}
+
+pub type ShareMap = TypeMap<UnsafeAny + Sync + Send>;
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+    use std::hash::{Hash, Hasher};
+
+    use super::{Key, TypeId, TypeIdHasher, TypeMap};
+
+    #[derive(Debug, PartialEq)]
+    struct KeyType;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct ValueType(u8);
+
+    impl Key for KeyType {
+        type Value = ValueType;
+    }
+
+    #[test]
+    fn test_pair_key_to_value() {
+        let mut map = TypeMap::new();
+        map.insert::<KeyType>(ValueType(32));
+
+        assert_eq!(*map.get::<KeyType>().unwrap(), ValueType(32));
+        assert!(map.contains::<KeyType>());
+    }
+
+    #[test]
+    fn test_type_id_hasher() {
+        fn verify_hashing_with(type_id: TypeId) {
+            let mut hasher = TypeIdHasher::default();
+            type_id.hash(&mut hasher);
+
+            assert_eq!(hasher.finish(), unsafe {
+                mem::transmute::<TypeId, u64>(type_id)
+            });
+        }
+
+        // Pick a variety of types, just to demonstrate it’s all sane.
+        // Normal, zero-sized, unsized, &c.
+        verify_hashing_with(TypeId::of::<usize>());
+        verify_hashing_with(TypeId::of::<()>());
+        verify_hashing_with(TypeId::of::<str>());
+        verify_hashing_with(TypeId::of::<&str>());
+        verify_hashing_with(TypeId::of::<Vec<u8>>());
+    }
+}


### PR DESCRIPTION
Implements a global read-only typemap.

This permit to have global data for all requests, that are requested on demand. See the new example, global_state, for an usage.

The new methods are :
- `Shio::manage`: add a new element to global context.
- `Context::get_global` and `Context::try_get_global` : similar to `Context::get` and `Context::try_get`, but in global context instead of request context.

This closes #13, and also provide the storage part of #12.