### PR TITLE
Split request data from request

### DIFF
--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -37,7 +37,7 @@ struct ResponseBody {
 fn index(ctx: Context) -> BoxFuture<Response, errors::Error> {
     // `tokio_io::io::read_to_end` will asynchronously read the request body, to completion,
     // and place it in the new vector.
-    io::read_to_end(ctx.body(), Vec::new())
+    io::read_to_end(ctx.data(), Vec::new())
         // `Future::from_err` acts like `?` in that it coerces the error type from
         // the future into the final error type
         .from_err()

--- a/lib/src/context.rs
+++ b/lib/src/context.rs
@@ -4,8 +4,9 @@ use tokio_core::reactor::Handle;
 use unsafe_any::UnsafeAny;
 
 use util::typemap::TypeMap;
-use request::{Body, Request};
+use request::Request;
 use state::{State, FromState};
+use Data;
 pub use state::Key;
 
 /// `Context` represents the context of the current HTTP request.
@@ -45,8 +46,8 @@ impl Context {
     }
 
     /// Take the request body.
-    pub fn body(self) -> Body {
-        self.request.body()
+    pub fn data(self) -> Data {
+        self.request.data()
     }
 
     /// Puts a value into the request state.

--- a/lib/src/context.rs
+++ b/lib/src/context.rs
@@ -5,7 +5,7 @@ use unsafe_any::UnsafeAny;
 
 use util::typemap::TypeMap;
 use request::Request;
-use state::{State, FromState};
+use state::{FromState, State};
 use Data;
 pub use state::Key;
 
@@ -28,12 +28,7 @@ pub struct Context {
 }
 
 impl Context {
-    pub(crate) fn new(
-        handle: Handle,
-        request: Request,
-        state: State,
-        body: Data,
-    ) -> Self {
+    pub(crate) fn new(handle: Handle, request: Request, state: State, body: Data) -> Self {
         Self {
             handle,
             request,

--- a/lib/src/context.rs
+++ b/lib/src/context.rs
@@ -24,6 +24,7 @@ pub struct Context {
     state: State,
     handle: Handle,
     request: Request,
+    body: Data,
 }
 
 impl Context {
@@ -31,11 +32,13 @@ impl Context {
         handle: Handle,
         request: Request,
         state: State,
+        body: Data,
     ) -> Self {
         Self {
             handle,
             request,
             state,
+            body,
         }
     }
 
@@ -47,7 +50,7 @@ impl Context {
 
     /// Take the request body.
     pub fn data(self) -> Data {
-        self.request.data()
+        self.body
     }
 
     /// Puts a value into the request state.
@@ -75,6 +78,11 @@ impl Context {
     /// Gets a reference to the shared state.
     pub fn shared(&self) -> &TypeMap<UnsafeAny + Send + Sync> {
         self.state.shared()
+    }
+
+    /// Deconstruct current context
+    pub fn deconstruct(self) -> (Handle, State, Request, Data) {
+        (self.handle, self.state, self.request, self.body)
     }
 }
 

--- a/lib/src/data.rs
+++ b/lib/src/data.rs
@@ -4,7 +4,7 @@ use hyper;
 use tokio_io::AsyncRead;
 use futures::{Async, Poll, Stream};
 
-pub struct Body {
+pub struct Data {
     body: hyper::Body,
 
     // Used as a buffer when reading the body through `tokio_io::AsyncRead`. This should
@@ -13,20 +13,20 @@ pub struct Body {
     chunk: Option<(hyper::Chunk, usize)>,
 }
 
-impl Body {
+impl Data {
     pub(crate) fn new(body: hyper::Body) -> Self {
         Self { body, chunk: None }
     }
 }
 
-impl Default for Body {
+impl Default for Data {
     fn default() -> Self {
         Self::new(Default::default())
     }
 }
 
 fn read_from_chunk(
-    body: &mut Body,
+    body: &mut Data,
     chunk: hyper::Chunk,
     mut buf: &mut [u8],
     index: usize,
@@ -42,7 +42,7 @@ fn read_from_chunk(
     Ok(written)
 }
 
-impl Read for Body {
+impl Read for Data {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if let Some((chunk, index)) = self.chunk.take() {
             return read_from_chunk(self, chunk, buf, index);
@@ -63,9 +63,9 @@ impl Read for Body {
     }
 }
 
-impl AsyncRead for Body {}
+impl AsyncRead for Data {}
 
-impl Stream for Body {
+impl Stream for Data {
     type Item = hyper::Chunk;
     type Error = hyper::Error;
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -24,6 +24,7 @@ pub mod request;
 pub mod errors;
 pub mod router;
 pub mod util;
+pub mod data;
 
 pub use hyper::{header, Method, StatusCode};
 
@@ -33,6 +34,7 @@ pub use shio::Shio;
 pub use context::Context;
 pub use state::State;
 pub use handler::Handler;
+pub use data::Data;
 
 /// Re-exports important traits and types. Meant to be glob imported when using Shio.
 pub mod prelude {

--- a/lib/src/request/mod.rs
+++ b/lib/src/request/mod.rs
@@ -1,15 +1,14 @@
-mod body;
 
 use hyper::{self, Method};
 
-pub use self::body::Body;
+pub use data::Data;
 
 pub struct Request {
     method: Method,
     uri: hyper::Uri,
     version: hyper::HttpVersion,
     headers: hyper::Headers,
-    body: Body,
+    body: Data,
 }
 
 impl Request {
@@ -27,7 +26,7 @@ impl Request {
             uri: components.1,
             version: components.2,
             headers: components.3,
-            body: Body::new(components.4),
+            body: Data::new(components.4),
         }
     }
 
@@ -63,7 +62,7 @@ impl Request {
 
     /// Take the request body.
     #[inline]
-    pub fn body(self) -> Body {
+    pub fn data(self) -> Data {
         self.body
     }
 }

--- a/lib/src/request/mod.rs
+++ b/lib/src/request/mod.rs
@@ -1,14 +1,11 @@
 
 use hyper::{self, Method};
 
-pub use data::Data;
-
 pub struct Request {
     method: Method,
     uri: hyper::Uri,
     version: hyper::HttpVersion,
     headers: hyper::Headers,
-    body: Data,
 }
 
 impl Request {
@@ -18,7 +15,6 @@ impl Request {
             hyper::Uri,
             hyper::HttpVersion,
             hyper::Headers,
-            hyper::Body,
         ),
     ) -> Self {
         Self {
@@ -26,7 +22,6 @@ impl Request {
             uri: components.1,
             version: components.2,
             headers: components.3,
-            body: Data::new(components.4),
         }
     }
 
@@ -58,11 +53,5 @@ impl Request {
     #[inline]
     pub fn path(&self) -> &str {
         self.uri.path()
-    }
-
-    /// Take the request body.
-    #[inline]
-    pub fn data(self) -> Data {
-        self.body
     }
 }

--- a/lib/src/request/mod.rs
+++ b/lib/src/request/mod.rs
@@ -10,12 +10,7 @@ pub struct Request {
 
 impl Request {
     pub(crate) fn new(
-        components: (
-            Method,
-            hyper::Uri,
-            hyper::HttpVersion,
-            hyper::Headers,
-        ),
+        components: (Method, hyper::Uri, hyper::HttpVersion, hyper::Headers),
     ) -> Self {
         Self {
             method: components.0,

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -127,7 +127,7 @@ mod tests {
     use hyper;
 
     use super::{Parameters, Router};
-    use {Context, Handler, State, Request, Response, StatusCode};
+    use {Context, Handler, Request, Response, State, StatusCode};
     use Method::*;
 
     // Empty handler to use for route tests

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -127,7 +127,7 @@ mod tests {
     use hyper;
 
     use super::{Parameters, Router};
-    use {Context, Handler, Request, Response, State, StatusCode};
+    use {Context, Handler, Response, State, StatusCode};
     use Method::*;
 
     // Empty handler to use for route tests
@@ -209,10 +209,8 @@ mod tests {
         // TODO: It should much easier to make a test context
         //       Perhaps `Request::build ( .. )` should be a thing?
         //       Proxied as `Context::build ( .. )` ?
-        let request = Request::new(
-            hyper::Request::new(Get, "/user/3289".parse().unwrap()).deconstruct(),
-        );
-        let context = Context::new(core.handle(), request, State::default());
+        let (request, data) = ::service::from_hyper_request(hyper::Request::new(Get, "/user/3289".parse().unwrap()));
+        let context = Context::new(core.handle(), request, State::default(), data);
 
         let work = router.call(context);
 
@@ -247,10 +245,8 @@ mod tests {
 
         let mut core = Core::new().unwrap();
 
-        let request = Request::new(
-            hyper::Request::new(Get, "/static/path/to/file/is/here".parse().unwrap()).deconstruct(),
-        );
-        let context = Context::new(core.handle(), request, State::default());
+        let (request, data) = ::service::from_hyper_request(hyper::Request::new(Get, "/static/path/to/file/is/here".parse().unwrap()));
+        let context = Context::new(core.handle(), request, State::default(), data);
 
         let work = router.call(context);
 

--- a/lib/src/service.rs
+++ b/lib/src/service.rs
@@ -58,7 +58,7 @@ where
     }
 }
 
-fn from_hyper(request: hyper::Request) -> (Request, Data) {
+pub(crate) fn from_hyper_request(request: hyper::Request) -> (Request, Data) {
     let (method, uri, version, header, body) = request.deconstruct();
     (
         Request::new((method, uri, version, header)),
@@ -76,7 +76,7 @@ where
     type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
 
     fn call(&self, request: Self::Request) -> Self::Future {
-        let (request, data) = from_hyper(request);
+        let (request, data) = from_hyper_request(request);
         let state = State::new(self.shared_state.clone());
         let ctx = Context::new(self.handle.clone(), request, state, data);
         let handler = self.handler.clone();

--- a/lib/src/service.rs
+++ b/lib/src/service.rs
@@ -60,7 +60,10 @@ where
 
 fn from_hyper(request: hyper::Request) -> (Request, Data) {
     let (method, uri, version, header, body) = request.deconstruct();
-    (Request::new((method, uri, version, header)), Data::new(body))
+    (
+        Request::new((method, uri, version, header)),
+        Data::new(body),
+    )
 }
 
 impl<H: Handler + 'static> hyper::server::Service for Service<H>

--- a/lib/src/shio.rs
+++ b/lib/src/shio.rs
@@ -9,7 +9,7 @@ use hyper::server::Http;
 use tokio_core::net::TcpListener;
 use tokio_core::reactor::Core;
 use net2::TcpBuilder;
-use util::typemap::{TypeMap, Key};
+use util::typemap::{Key, TypeMap};
 use unsafe_any::UnsafeAny;
 
 #[cfg(unix)]

--- a/lib/src/state.rs
+++ b/lib/src/state.rs
@@ -84,10 +84,10 @@ where
     <T as Key>::Value: Send + Sync,
 {
     default fn from_state(state: &State) -> &<T as Key>::Value {
-                state
-                    .shared
-                    .try_get::<T>()
-                    .or_else(|| state.request.try_get::<T>())
+        state
+            .shared
+            .try_get::<T>()
+            .or_else(|| state.request.try_get::<T>())
     }
 }
 


### PR DESCRIPTION
This is an implementation for #17, except all related to [http](https://github.com/hyperium/http) crate, because we need to wait hyper to do so.

- Moved & renamed `shio::request::Body` to `shio::Data`
- Renamed `Context::body()` to `Context::data()`
- Moved request data from `shio::Request` to `shio::Context`
- Add `Context::deconstruct()`, that return `(Handle, State, Request, Data)`