### PR TITLE
Add context::Builder

### DIFF
--- a/lib/src/context/builder.rs
+++ b/lib/src/context/builder.rs
@@ -1,0 +1,96 @@
+
+use tokio_core::reactor::Handle;
+use std::sync::Arc;
+use unsafe_any::UnsafeAny;
+use hyper::{Method, Uri, error, HttpVersion, Headers, Body};
+use hyper::header::Header;
+
+use super::Context;
+use state::State;
+use util::typemap::TypeMap;
+use request::Request;
+use data;
+
+/// Helper struct for construct a [`Context`]
+///
+/// [`Context`]: struct.Context.html
+pub struct Builder {
+    handle: Handle,
+
+    state: State,
+
+    // for request
+    method: Method,
+    uri: Result<Uri, error::UriError>,
+    version: HttpVersion,
+    headers: Headers,
+    body: Body,
+}
+
+impl Builder {
+    /// Create a new `ContextBuilder` from a tokio_core `Handle`
+    pub fn new(handle: Handle) -> Self {
+        Self {
+            handle,
+            state: State::default(),
+            method: Method::Get,
+            uri: "/".parse::<Uri>(),
+            version: HttpVersion::Http11,
+            headers: Headers::new(),
+            body: Body::default(),
+        }
+    }
+
+    /// Set the shared data.
+    pub fn shared(mut self, shared: Arc<TypeMap<UnsafeAny + Send + Sync>>) -> Self {
+        self.state.shared = shared;
+        self
+    }
+
+    /// Set the HTTP method to `method`
+    pub fn method(mut self, method: Method) -> Self {
+        self.method = method;
+        self
+    }
+
+    /// Set the uri
+    pub fn uri(mut self, uri: &str) -> Self {
+        self.uri = uri.parse::<Uri>();
+        self
+    }
+
+    /// Set the HTTP version
+    pub fn version(mut self, ver: HttpVersion) -> Self {
+        self.version = ver;
+        self
+    }
+
+    /// Set an header
+    pub fn set_header<H: Header>(mut self, value: H) -> Self {
+        self.headers.set(value);
+        self
+    }
+
+    /// Set the request data
+    pub fn set_data<B: Into<Body>>(mut self, body: B) -> Self {
+        self.body = body.into();
+        self
+    }
+
+    /// Create the `Context`, returning any error that occurs during build.
+    pub fn finalize(self) -> Result<Context, error::UriError> {
+        let Self {
+            handle, state,
+            method, uri,
+            version, headers,
+            body
+        } = self;
+
+        let uri = uri?;
+
+        let request = Request::new((method, uri, version, headers));
+        let context = Context::new(handle, request, state, data::Data::new(body));
+        Ok(context)
+    }
+}
+

--- a/lib/src/context/mod.rs
+++ b/lib/src/context/mod.rs
@@ -1,3 +1,5 @@
+mod builder;
+
 use std::ops::Deref;
 
 use tokio_core::reactor::Handle;
@@ -8,6 +10,8 @@ use request::Request;
 use state::{FromState, State};
 use Data;
 pub use state::Key;
+
+pub use self::builder::Builder;
 
 /// `Context` represents the context of the current HTTP request.
 ///
@@ -78,6 +82,13 @@ impl Context {
     /// Deconstruct current context
     pub fn deconstruct(self) -> (Handle, State, Request, Data) {
         (self.handle, self.state, self.request, self.body)
+    }
+    
+    /// Create a new context [`Builder`]
+    ///
+    /// [`Builder`]: struct.Builder.html
+    pub fn builder(handle: Handle) -> Builder {
+        Builder::new(handle)
     }
 }
 

--- a/lib/src/router/mod.rs
+++ b/lib/src/router/mod.rs
@@ -124,10 +124,9 @@ impl Handler for Router {
 #[cfg(test)]
 mod tests {
     use tokio_core::reactor::Core;
-    use hyper;
 
     use super::{Parameters, Router};
-    use {Context, Handler, Response, State, StatusCode};
+    use {Context, Handler, Response, StatusCode};
     use Method::*;
 
     // Empty handler to use for route tests
@@ -205,12 +204,9 @@ mod tests {
         }));
 
         let mut core = Core::new().unwrap();
-
-        // TODO: It should much easier to make a test context
-        //       Perhaps `Request::build ( .. )` should be a thing?
-        //       Proxied as `Context::build ( .. )` ?
-        let (request, data) = ::service::from_hyper_request(hyper::Request::new(Get, "/user/3289".parse().unwrap()));
-        let context = Context::new(core.handle(), request, State::default(), data);
+        let context = Context::builder(core.handle())
+            .uri("/user/3289")
+            .finalize().unwrap();
 
         let work = router.call(context);
 
@@ -244,9 +240,9 @@ mod tests {
         }));
 
         let mut core = Core::new().unwrap();
-
-        let (request, data) = ::service::from_hyper_request(hyper::Request::new(Get, "/static/path/to/file/is/here".parse().unwrap()));
-        let context = Context::new(core.handle(), request, State::default(), data);
+        let context = Context::builder(core.handle())
+            .uri("/static/path/to/file/is/here")
+            .finalize().unwrap();
 
         let work = router.call(context);
 

--- a/lib/src/state.rs
+++ b/lib/src/state.rs
@@ -10,7 +10,7 @@ pub struct State {
     request: TypeMap,
 
     /// State shared across all requests.
-    shared: Arc<TypeMap<UnsafeAny + Send + Sync>>,
+    pub(crate) shared: Arc<TypeMap<UnsafeAny + Send + Sync>>,
 }
 
 impl Default for State {


### PR DESCRIPTION
Add `context::Builder`, a helper struct for creating a `Context`.
Also modify `Router` tests to use the new `Builder`.

Closes #22 