### PR TITLE
Handle errors from listener threads failing to start

### DIFF
--- a/lib/src/shio.rs
+++ b/lib/src/shio.rs
@@ -120,11 +120,13 @@ where
         while !children.is_empty() {
             let respawn = 'outer: loop {
                 for child in children.drain(..) {
-                    if child.join().is_err() {
+                    match child.join() {
+                        Ok(Ok(_)) => continue,
+                        Ok(Err(e)) => return Err(e),
                         // Thread panicked; spawn another one
                         // TODO: Should there be any sort of limit/backoff here?
-                        break 'outer true;
-                    }
+                        Err(_) => break 'outer true
+                    };
                 }
 
                 break false;


### PR DESCRIPTION
Hi @mehcode,

This fix allows handling socket errors when calling `run()`, such as trying to listen on a privileged port as a non-root user. Before the fix, `run()` will always return `Ok`, so even calling `unwrap()` on its result will always succeed.

Here's a simple program that reproduces the issue (run it as a non-root user):

```rust
extern crate shio;

use shio::prelude::*;

fn main() {
    let server = Shio::new(move |ctx: Context| {
        Response::with("Hi")
    });
    match server.run("0.0.0.0:80") {
        Ok(_) => println!("Listening on port 80"),
        Err(e) => {
            println!("Failed to start server: {}", e);
            ::std::process::exit(1);
        }
    };
}
```

This is only my first week writing Rust, so please let me know if there's something I should have done differently.

Thanks!