### PR TITLE
Allow chaining threads() during init.

### DIFF
--- a/lib/src/shio.rs
+++ b/lib/src/shio.rs
@@ -52,8 +52,9 @@ where
     }
 
     /// Set the number of threads to use.
-    pub fn threads(&mut self, threads: usize) {
+    pub fn threads(&mut self, threads: usize) -> &mut Self {
         self.threads = threads;
+        self
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(use_debug, never_loop))]


### PR DESCRIPTION
return Self from `threads()` so it can be chained during init, allowing to make code like below read better:
```diff
diff --git a/src/main.rs b/src/main.rs
index 00fa849..fdb9f36 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,13 +52,14 @@ fn main() {
     thread::spawn(move || {
-        let mut shio = Shio::default();
-        shio.threads(4);
-        shio.route((
-            Method::GET,
-            "/",
-            Handler { },
-        ))
+        Shio::default()
+            .threads(4)
+            .route((
+                Method::GET,
+                "/",
+                Handler { },
+            ))
             .run(":7878")
             .unwrap()
     });
```